### PR TITLE
Check that the error object (e) is not null

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -39,15 +39,17 @@
             } else {
                 logger.log(fileMessage);
                 lint.errors.forEach(function (e, i) {
-                    pad = "#" + String(i + 1);
-                    while (pad.length < 3) {
-                        pad = ' ' + pad;
-                    }
-                    line = ' // Line ' + e.line + ', Pos ' + e.character;
+                    if (e) {
+                        pad = "#" + String(i + 1);
+                        while (pad.length < 3) {
+                            pad = ' ' + pad;
+                        }
+                        line = ' // Line ' + e.line + ', Pos ' + e.character;
 
-                    logger.log(pad + ' ' + (colorize ? color.yellow(e.reason) : e.reason));
-                    logger.log('    ' + (e.evidence || '').replace(/^\s+|\s+$/, "") +
-                               (colorize ? color.grey(line) : line));
+                        logger.log(pad + ' ' + (colorize ? color.yellow(e.reason) : e.reason));
+                        logger.log('    ' + (e.evidence || '').replace(/^\s+|\s+$/, "") +
+                            (colorize ? color.grey(line) : line));
+                    }
                 });
             }
         } else {


### PR DESCRIPTION
This fixes the followint error 

```
#51 Too many errors. (20% scanned).
      // Line 33, Pos 4

/usr/lib/node_modules/jslint/lib/reporter.js:46
                    line = ' // Line ' + e.line + ', Pos ' + e.character;
                                          ^
TypeError: Cannot read property 'line' of null
    at /usr/lib/node_modules/jslint/lib/reporter.js:46:43
    at Array.forEach (native)
    at Object.exports.report (/usr/lib/node_modules/jslint/lib/reporter.js:41:29)
    at Object.report (/usr/lib/node_modules/jslint/lib/reporter.js:21:39)
    at ReportStream_constructor.ReportStream_transform [as _transform] (/usr/lib/node_modules/jslint/lib/reportstream.js:48:23)
    at ReportStream_constructor.Transform._read (/usr/lib/node_modules/jslint/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at ReportStream_constructor.Transform._write (/usr/lib/node_modules/jslint/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/usr/lib/node_modules/jslint/node_modules/readable-stream/lib/_stream_writable.js:238:10)
    at writeOrBuffer (/usr/lib/node_modules/jslint/node_modules/readable-stream/lib/_stream_writable.js:228:5)
    at ReportStream_constructor.Writable.write (/usr/lib/node_modules/jslint/node_modules/readable-stream/lib/_stream_writable.js:195:11)
```

This problem exists versions  0.4.0, 0.4.1 and 0.5.0 and most probably is related to #73
